### PR TITLE
fix(Настройка базы знаний): исправил конфигурацию в разделе git.core

### DIFF
--- a/cards/Настройка распределенной Базы знаний с Obsidian и Git.md
+++ b/cards/Настройка распределенной Базы знаний с Obsidian и Git.md
@@ -106,7 +106,6 @@ tree
 	bare = false
 	autocrlf = false
 	trustctime = false
-	[core]
 ```
 
 > У разных версий `git` будут отличаться знаки разделителя блоков в форматировании файла `.git/config`.


### PR DESCRIPTION
В заметке `cards/Настройка распределенной Базы знаний с Obsidian и Git.md` в разделе `Шаг 4 Настраиваем Git` 
исправил в конфигурацию в разделе git.core.